### PR TITLE
Refactor emotion detector, add model, update README, and add tests

### DIFF
--- a/Face Emotion Recognition/README.md
+++ b/Face Emotion Recognition/README.md
@@ -16,7 +16,6 @@ This repository provides a PyTorch implementation of the research paper, [Deep-E
 This implementation uses the following datasets:
 - [FER2013](https://www.kaggle.com/c/challenges-in-representation-learning-facial-expression-recognition-challenge/data)
 
-
 ## Prerequisites
 Make sure you have the following libraries installed:
 - PyTorch >= 1.1.0
@@ -26,51 +25,33 @@ Make sure you have the following libraries installed:
 - Pillow (PIL)
 
 ## Repository Structure
-This repository is organized as follows:
-- [`main`](/main.py): Contains setup for the dataset and training loop.
-- [`visualize`](/visualize.py): Includes source code for evaluating the model on test data and real-time testing using a webcam.
-- [`model`](/model.py): Defines the model class.
-- [`data_loaders`](/data_loaders.py): Contains the dataset class.
-- [`generate_data`](/generate_data.py): Sets up the [dataset](https://www.kaggle.com/c/challenges-in-representation-learning-facial-expression-recognition-challenge/data).
-
+This project is organized as follows:
+- [`emotion_detector.py`](./emotion_detector.py): CLI runner for model loading, evaluation, and webcam inference.
+- [`deep_emotion_model.py`](./deep_emotion_model.py): Defines the `DeepEmotionModel` class.
+- [`imgs/`](./imgs): Architecture and prediction sample images.
 
 ### Data Preparation
 1. Download the dataset from [Kaggle](https://www.kaggle.com/c/challenges-in-representation-learning-facial-expression-recognition-challenge/data).
-2. Decompress `train.csv` and `test.csv` into the `./data` folder.
+2. Arrange the test dataset in ImageFolder format (one folder per class label).
 
 ### How to Run
-**Setup the Dataset**
+**Evaluate test accuracy**
 ```bash
-python main.py [-s [True]] [-d [data_path]]
-
---setup                 Setup the dataset for the first time
---data                  Data folder that contains data files
+python emotion_detector.py --model <model_path> --data <test_data_dir> --test_acc
 ```
 
-**To train the model**
-```
-python main.py [-t] [--data [data_path]] [--hparams [hyperparams]]
-              [--epochs] [--learning_rate] [--batch_size]
+- `--model`: Path to pretrained model checkpoint (`.pth`).
+- `--data`: Root test data directory in ImageFolder structure.
+- `--test_acc`: Calculate test accuracy.
 
---data                  Data folder that contains training and validation files
---train                 True when training
---hparams               True when changing the hyperparameters
---epochs                Number of epochs
---learning_rate         Learning rate value
---batch_size            Training/validation batch size
+**Run webcam inference**
+```bash
+python emotion_detector.py --model <model_path> --data <test_data_dir> --webcam
 ```
 
-**To validate the model**
-```
-python visualize.py [-t] [-c] [--data [data_path]] [--model [model_path]]
+- `--webcam`: Run real-time prediction with a connected webcam.
 
---data                  Data folder that contains test images and test CSV file
---model                 Path to pretrained model
---test_cc               Calculate the test accuracy
---cam                   Test the model in real-time with webcam connected via USB
-```
 ## Prediction Samples
 <p align="center">
   <img src="imgs/samples.png" width="720" title="Deep-Emotion Architecture">
 </p>
-```

--- a/Face Emotion Recognition/deep_emotion_model.py
+++ b/Face Emotion Recognition/deep_emotion_model.py
@@ -1,1 +1,37 @@
+import torch
+from torch import nn
 
+
+class DeepEmotionModel(nn.Module):
+    """CNN for 48x48 grayscale facial emotion classification.
+
+    The model returns logits for 7 FER2013 classes.
+    """
+
+    def __init__(self, num_classes: int = 7) -> None:
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(1, 32, kernel_size=3, padding=1),
+            nn.BatchNorm2d(32),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.BatchNorm2d(64),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2),
+            nn.Conv2d(64, 128, kernel_size=3, padding=1),
+            nn.BatchNorm2d(128),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(128 * 6 * 6, 256),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=0.3),
+            nn.Linear(256, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        return self.classifier(x)

--- a/Face Emotion Recognition/emotion_detector.py
+++ b/Face Emotion Recognition/emotion_detector.py
@@ -1,16 +1,12 @@
-
-import os
-import sys
 import argparse
-import cv2
-import torch
-import numpy as np
-from PIL import Image
-from torchvision import transforms
-from torch.utils.data import DataLoader
+from pathlib import Path
 
-# Assuming DeepEmotionModel is defined in a separate file
+import torch
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
 from deep_emotion_model import DeepEmotionModel
+
 
 class EmotionDetector:
     def __init__(self, model_path, data_path, use_webcam=False, test_accuracy=False):
@@ -21,29 +17,91 @@ class EmotionDetector:
         self.test_accuracy = test_accuracy
         self.model = self.load_model()
         self.transformation = self.get_transformations()
-        self.classes = ['Angry', 'Disgust', 'Fear', 'Happy', 'Sad', 'Surprise', 'Neutral']
+        self.classes = ["Angry", "Disgust", "Fear", "Happy", "Sad", "Surprise", "Neutral"]
 
     def load_model(self):
         model = DeepEmotionModel()
-        model.load_state_dict(torch.load(self.model_path))
+        state_dict = torch.load(self.model_path, map_location=self.device)
+        model.load_state_dict(state_dict)
         model.to(self.device)
         model.eval()
         return model
 
     def get_transformations(self):
-        return transforms.Compose([
-            transforms.ToTensor(),
-            transforms.Normalize((0.5,), (0.5,))
-        ])
+        return transforms.Compose(
+            [
+                transforms.Grayscale(num_output_channels=1),
+                transforms.Resize((48, 48)),
+                transforms.ToTensor(),
+                transforms.Normalize((0.5,), (0.5,)),
+            ]
+        )
+
+    def _build_test_dataset(self):
+        dataset_path = Path(self.data_path)
+        if not dataset_path.exists():
+            raise FileNotFoundError(f"Test data path not found: {dataset_path}")
+
+        return datasets.ImageFolder(root=str(dataset_path), transform=self.transformation)
 
     def evaluate_test_data(self):
-        test_dataset = CustomDataset(self.data_path, transform=self.transformation)
+        test_dataset = self._build_test_dataset()
         test_loader = DataLoader(test_dataset, batch_size=64, num_workers=0)
-        # Evaluate model on test data...
+
+        correct = 0
+        total = 0
+        with torch.no_grad():
+            for images, labels in test_loader:
+                images = images.to(self.device)
+                labels = labels.to(self.device)
+                outputs = self.model(images)
+                predictions = outputs.argmax(dim=1)
+                total += labels.size(0)
+                correct += (predictions == labels).sum().item()
+
+        accuracy = (correct / total) * 100 if total else 0.0
+        print(f"Test accuracy: {accuracy:.2f}% ({correct}/{total})")
+        return accuracy
 
     def webcam_emotion_detection(self):
-        # Real-time emotion detection logic...
-        pass
+        import cv2
+
+        cap = cv2.VideoCapture(0)
+        if not cap.isOpened():
+            raise RuntimeError("Unable to open webcam")
+
+        print("Webcam mode started. Press 'q' to quit.")
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            face = cv2.resize(gray, (48, 48))
+            tensor = self.transformation(face).unsqueeze(0).to(self.device)
+
+            with torch.no_grad():
+                logits = self.model(tensor)
+                pred = int(logits.argmax(dim=1).item())
+
+            label = self.classes[pred]
+            cv2.putText(
+                frame,
+                label,
+                (20, 40),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                1,
+                (0, 255, 0),
+                2,
+                cv2.LINE_AA,
+            )
+            cv2.imshow("Emotion detection", frame)
+
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                break
+
+        cap.release()
+        cv2.destroyAllWindows()
 
     def run(self):
         if self.test_accuracy:
@@ -51,12 +109,18 @@ class EmotionDetector:
         if self.use_webcam:
             self.webcam_emotion_detection()
 
-if __name__ == "__main__":
+
+def build_arg_parser():
     parser = argparse.ArgumentParser(description="Emotion Detection")
-    parser.add_argument('--model', required=True, help='Path to the trained model')
-    parser.add_argument('--data', required=True, help='Path to test data')
-    parser.add_argument('--test_acc', action='store_true', help='Evaluate test accuracy')
-    parser.add_argument('--webcam', action='store_true', help='Use webcam for real-time detection')
+    parser.add_argument("--model", required=True, help="Path to the trained model")
+    parser.add_argument("--data", required=True, help="Path to test data")
+    parser.add_argument("--test_acc", action="store_true", help="Evaluate test accuracy")
+    parser.add_argument("--webcam", action="store_true", help="Use webcam for real-time detection")
+    return parser
+
+
+if __name__ == "__main__":
+    parser = build_arg_parser()
     args = parser.parse_args()
 
     detector = EmotionDetector(args.model, args.data, args.webcam, args.test_acc)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_readme_uses_test_acc_flag():
+    readme = Path('Face Emotion Recognition/README.md').read_text(encoding='utf-8')
+    assert '--test_acc' in readme
+    assert '--test_cc' not in readme

--- a/tests/test_model_torch.py
+++ b/tests/test_model_torch.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+torch = pytest.importorskip('torch')
+
+PROJECT_DIR = Path(__file__).resolve().parents[1] / 'Face Emotion Recognition'
+sys.path.insert(0, str(PROJECT_DIR))
+
+from deep_emotion_model import DeepEmotionModel
+from emotion_detector import EmotionDetector, build_arg_parser
+
+
+def test_model_forward_shape():
+    model = DeepEmotionModel(num_classes=7)
+    x = torch.randn(2, 1, 48, 48)
+    out = model(x)
+    assert out.shape == (2, 7)
+
+
+def test_transform_contains_grayscale_and_normalize(tmp_path):
+    with patch.object(EmotionDetector, 'load_model', return_value=MagicMock()):
+        detector = EmotionDetector('model.pth', str(tmp_path))
+
+    names = [t.__class__.__name__ for t in detector.transformation.transforms]
+    assert 'Grayscale' in names
+    assert 'Normalize' in names
+
+
+def test_load_model_uses_map_location(tmp_path):
+    model_file = tmp_path / 'model.pth'
+    model_file.write_text('placeholder')
+
+    dummy_model = MagicMock()
+    with patch('emotion_detector.DeepEmotionModel', return_value=dummy_model), patch(
+        'emotion_detector.torch.load', return_value={'weights': 'mock'}
+    ) as mock_load:
+        detector = EmotionDetector.__new__(EmotionDetector)
+        detector.device = torch.device('cpu')
+        detector.model_path = str(model_file)
+
+        loaded_model = EmotionDetector.load_model(detector)
+
+    assert loaded_model is dummy_model
+    mock_load.assert_called_once_with(str(model_file), map_location=detector.device)
+
+
+def test_cli_flag_test_acc_parses():
+    parser = build_arg_parser()
+    args = parser.parse_args(['--model', 'm.pth', '--data', './data', '--test_acc'])
+    assert args.test_acc is True


### PR DESCRIPTION
### Motivation
- Replace the old script layout with a focused CLI and a model class to simplify evaluation and webcam inference.
- Provide a minimal, self-contained `DeepEmotionModel` suitable for 48x48 FER2013 images and ensure transformations are applied consistently.
- Improve reliability of model loading across devices by using `map_location` when calling `torch.load` and implement end-to-end test and webcam flows.
- Update documentation to reflect the new CLI and ImageFolder test dataset layout.

### Description
- Added `deep_emotion_model.py` implementing `DeepEmotionModel` (a small CNN that returns logits for 7 classes) and exposed a `forward` returning shape `(N, 7)`.
- Added `emotion_detector.py` which provides `EmotionDetector` and `build_arg_parser`; it loads the model with `torch.load(..., map_location=self.device)`, applies transforms including `Grayscale` and `Resize((48,48))`, evaluates test accuracy using `torch.no_grad()` over an `ImageFolder` dataset, and implements webcam inference via OpenCV.
- Updated `README.md` to remove references to the old scripts, document `emotion_detector.py` and `deep_emotion_model.py`, instruct users to provide test data in ImageFolder format, and show usage with `--model`, `--data`, `--test_acc`, and `--webcam` flags.
- Added unit tests: `tests/test_model_torch.py` to validate model forward shape, transform composition, `torch.load` usage with `map_location`, and CLI parsing, and `tests/test_docs.py` to assert README uses `--test_acc`.

### Testing
- Ran `pytest` on the repository which executed the new tests in `tests/test_model_torch.py` and `tests/test_docs.py`, and all tests passed.
- The model forward shape test used `torch.randn(2,1,48,48)` and asserted the output shape is `(2,7)` which succeeded.
- The transform and CLI parsing tests were executed and validated the presence of `Grayscale`/`Normalize` in the pipeline and proper parsing of `--test_acc`, both succeeding.
- The `torch.load` map-location usage test mocked `torch.load` and confirmed it was called with `map_location=detector.device`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c521e1d8bc832480fd83d3036dd4ef)